### PR TITLE
Support downloading ZIP assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # Project specific
 downloaded/
+.vscode/

--- a/Downloader/DataTools.py
+++ b/Downloader/DataTools.py
@@ -2,8 +2,9 @@ import os
 import re
 
 from PIL import Image
+from zipfile import ZipFile
 
-class ImageSaver:
+class ResourceSaver:
     DefaultDownloadDataFolderPath = "/downloaded"
 
     def createFolder(folderName):
@@ -11,8 +12,12 @@ class ImageSaver:
             os.makedirs(folderName, exist_ok=True)
 
     def saveImage(image : Image, saveDirectory, fileName):
-        ImageSaver.createFolder(f"./{saveDirectory}")
+        ResourceSaver.createFolder(f"./{saveDirectory}")
         image.save(f"./{saveDirectory}/{fileName}.png")
+
+    def saveZip(file: ZipFile, directory: str, fileName: str):
+        ResourceSaver.createFolder(f'./{directory}')
+        file.extractall(f'./{directory}/{fileName}')
 
 class StringHelper:
     def cleanString(string: str):


### PR DESCRIPTION
I tried using this tool to download assets for a game that included some ZIP archives. This did not work because an element with the `sheet-container` id could not be found on the page of any ZIP assets. This PR introduces some relatively minor changes that locate and automatically extract the contents of any ZIP assets as well as standard spritesheet images.